### PR TITLE
Remove PHP "Deprecated", user sciper to recover user instead of username

### DIFF
--- a/EPFL-Tequila.php
+++ b/EPFL-Tequila.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Tequila
  * Description: Authenticate to WordPress with Tequila
- * Version:     0.15 (vpsi)
+ * Version:     0.16 (vpsi)
  * Author:      Dominique Quatravaux
  * Author URI:  mailto:dominique.quatravaux@epfl.ch
  */

--- a/EPFL-Tequila.php
+++ b/EPFL-Tequila.php
@@ -190,7 +190,7 @@ class Controller
          * @param array $tequila_data The data received from Tequila
          */
         do_action("tequila_save_user", $tequila_data);
-        $user = get_user_by("login", $tequila_data["username"]);
+        $user = get_user_by("slug", $tequila_data["uniqueid"]);
         if (gettype($user) === "boolean" && $user === false) {
             $user = null;
         }

--- a/inc/tequila_client.php
+++ b/inc/tequila_client.php
@@ -56,19 +56,19 @@ class TequilaClient
             $requestInfos ['service'] = $this->sApplicationName;
         }
         if (!empty($this->aWantedRights)) {
-            $requestInfos ['wantright'] = implode($this->aWantedRights, '+');
+            $requestInfos ['wantright'] = implode('+', $this->aWantedRights);
         }
         if (!empty($this->aWantedRoles)) {
-            $requestInfos ['wantrole'] =  implode($this->aWantedRoles, '+');
+            $requestInfos ['wantrole'] =  implode('+', $this->aWantedRoles);
         }
         if (!empty($this->aWantedAttributes)) {
-            $requestInfos ['request'] = implode($this->aWantedAttributes, '+');
+            $requestInfos ['request'] = implode('+', $this->aWantedAttributes);
         }
         if (!empty($this->aWishedAttributes)) {
-            $requestInfos ['wish'] = implode($this->aWishedAttributes, '+');
+            $requestInfos ['wish'] = implode('+', $this->aWishedAttributes);
         }
         if (!empty($this->aWantedGroups)) {
-            $requestInfos ['belongs'] = implode($this->aWantedGroups, '+');
+            $requestInfos ['belongs'] = implode('+', $this->aWantedGroups);
         }
         if (!empty($this->sCustomFilter)) {
             $requestInfos ['require'] = $this->sCustomFilter;


### PR DESCRIPTION
- Utilisation du sciper pour récupérer un utilisateur, comme fait ici https://github.com/epfl-sti/wordpress.plugin.accred/pull/13
- Petit changement suite à la vue du message suivant dans les logs:
> PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /wp/5.5.1/wp-content/plugins/tequila/inc/tequila_client.php on line 65